### PR TITLE
Avoid pendulum v3 problem in uliweb 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,7 @@ setup(name='Uliweb3',
     license=uliweb.__license__,
     include_package_data=True,
     install_requires=[
-      'pendulum',
+      'pendulum<3.0',
       'six',
       'werkzeug',
       'ua-parser'


### PR DESCRIPTION
When installing uliweb 3, it raises exception: ModuleNotFoundError: No module named 'pendulum.tz.zoneinfo'
Cause by https://github.com/sdispater/pendulum/issues/723